### PR TITLE
Fixes a bug where `FS is not defined`

### DIFF
--- a/package.js
+++ b/package.js
@@ -13,6 +13,9 @@ Package.onUse(function(api) {
   api.use('cfs:standard-packages@0.0.2', ['client', 'server'], {weak: true});
   api.use('raix:ui-dropped-event@0.0.7', 'client');
 
+  // ensure standard packages are available globally incase the user didn't `meteor add cfs:standard-packages`
+  api.imply('cfs:standard-packages')
+
   api.export('CfsAutoForm', 'client');
 
   api.add_files([


### PR DESCRIPTION
Fixes a bug where `FS is not defined`

If the user didn't `meteor add cfs:standard-packages` (say they added a different package which depends on `cfs:autoform`), FS will not be available globally and will explode here: https://github.com/aldeed/meteor-cfs-autoform/blob/master/cfs-autoform.js#L81

Either the third party package needs to imply `cfs:standard-packages` for `cfs:autoform` or `cfs:autoform` needs to imply `cfs:standard-packages`. I've gone with the latter.

Cheers