### PR TITLE
improved handling of multiple files

### DIFF
--- a/cfs-autoform-hooks.js
+++ b/cfs-autoform-hooks.js
@@ -66,13 +66,11 @@ Hooks = {
       // or push it into the array of IDs if it's a multiple files field.
       else {
         if (arrayFields[key]) {
-          CfsAutoForm.Util.deepFind(doc,key).push(fileObj._id);
+          CfsAutoForm.Util.deepPush(doc, key, fileObj._id);
         } else {
-          //doc[key] = fileObj._id;
           CfsAutoForm.Util.deepSet(doc,key,fileObj._id);
         }
       }
-
       // If this is the last file to be processed, pass execution back to autoform
       if (doneFiles === totalFiles) {
         // If any files failed
@@ -89,7 +87,6 @@ Hooks = {
         }
       }
     }
-
     // Loop through all hidden file fields, inserting
     // and uploading all files that have been attached to them.
     template.$('.cfsaf-hidden').each(function () {
@@ -118,6 +115,7 @@ Hooks = {
             uploadedFiles.push(fileObj);
             elem.data("cfsaf_uploaded-files", uploadedFiles);
             // call callback
+
             cb(null, fileObj, key);
           });
 

--- a/cfs-autoform-util.js
+++ b/cfs-autoform-util.js
@@ -6,6 +6,14 @@ Util = {
       delete obj[prop];
     });
   },
+  deepPush: function(obj, prop, value){
+    return CfsAutoForm.Util.deepDo(obj,prop, function(obj, prop){
+      if(!obj[prop]){
+        obj[prop] = [];
+      }
+      obj[prop].push(value);
+    })
+  },
   deepSet: function(obj, prop, value){
     return CfsAutoForm.Util.deepDo(obj, prop, function(obj, prop){
       obj[prop] = value;
@@ -16,7 +24,6 @@ Util = {
     path = path.split('.');
     for (i = 0; i < path.length - 1; i++)
       obj = obj[path[i]];
-
     return obj;
   },
   //executes closure(obj, prop) where prop might be a string of properties and array indices


### PR DESCRIPTION
This makes it so you you can use `[String]` on the cfs-files and it will have an array of ids of the files.  However you have to specify cfs-files in the template, it doesn't seem to work when you specify in the schema.