### PR TITLE
Update to fix issue when CfsAutoForm.Hooks.beforeInsert() is called f…

### DIFF
--- a/cfs-autoform-hooks.js
+++ b/cfs-autoform-hooks.js
@@ -1,6 +1,6 @@
 Hooks = {
   beforeInsert: function (doc) {
-    var self = this, template = this.template;
+    var self = this, template = this.template ? this.template : Template.instance();
     if (!AutoForm.validateForm(this.formId)) {
       return false;
     }


### PR DESCRIPTION
Update to fix issue when CfsAutoForm.Hooks.beforeInsert() is called from a function rather than passed directly to the Autoform before hook (see issue at: [#45](https://github.com/aldeed/meteor-cfs-autoform/issues/45))
